### PR TITLE
Update first part of notebook 3 with more explanation of forwad models

### DIFF
--- a/training/Exercise03_Forward_Models.ipynb
+++ b/training/Exercise03_Forward_Models.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# Exercise 03: Forward models, data generation and forward UQ\n",
     "\n",
-    "In this notebook, we dive into forward models in CUQIpy. In brief, a forward model is defined as a mathematical model that describes the models the relationship between some input parameters (which are often a quantity we can not directly observe) and some output data (which is observable).\n",
+    "In this notebook, we dive into forward models in CUQIpy. In brief, a forward model is defined as a mathematical model that describes the relationship between some input parameters (which are not directly observable) and some output data (which is observable).\n",
     "\n",
-    "In the context of inverse problems forward models are an important concept. What distinguishes forward models for inverse problems to any other kind of model of a physical system, is that they are *ill-posed*, which means existence, uniqueness and stability of inversion cannot be guaranteed. This deserves a separate discussion and we refer to [1] for the interested reader.\n",
+    "In the context of inverse problems forward models are an important concept. What distinguishes forward models for inverse problems to any other kind of model of a physical system, is that they are *ill-posed*, which means existence, uniqueness and stability of inversion cannot be guaranteed. This deserves a separate discussion, which is out-of-scope for this notebook and we refer to [1] for the interested reader.\n",
     "\n",
     "For the purpose of this notebook, we show the basics of how to use forward models in CUQIpy. In particular for generating simulated noisy data and some forward uncertainty quantification. Finally, we also show how to define new custom linear or non-linear forward models in CUQIpy from either a matrix or functions.\n",
     "\n",
@@ -25,7 +25,7 @@
     "1. [Access forward models from test problems](#testproblems)\n",
     "2. [Basic usage of forward models](#models)\n",
     "3. [Generating synthetic data](#data)\n",
-    "4. [★ Creating custom forward models](#custom)\n",
+    "4. [Creating custom forward models](#custom)\n",
     "5. [★ Forward UQ](#forwardUQ)\n",
     "\n",
     "## References\n",
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
    "metadata": {},
    "source": [
     "# 1. Access forward models from test problems<a class=\"anchor\" id=\"testproblems\"></a>\n",
-    "As mentioned in the introduction, forward models in CUQIpy are the link between the parameter of interest (which we call solution), say $\\mathbf{x}$, and the observed data, say $\\mathbf{y}$. In their simplest form they are simply a mapping $A: \\mathbf{x} \\mapsto \\mathbf{y}$.\n",
+    "Forward models in CUQIpy are the link between the parameter of interest (which we call solution), say $\\mathbf{x}$, and the observed data, say $\\mathbf{y}$. In their simplest form they are simply a mapping $A: \\mathbf{x} \\mapsto \\mathbf{y}$. In CUQIpy forward models are so commonly used, that we refer to them simply as models.\n",
     "\n",
     "In addition to providing a mapping for the \"forward\" operation and potentially the adjoint, a CUQIpy model also contains information on the parametrization of its domain and range as well as possible gradients and so on. \n",
     "\n",
@@ -75,17 +75,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "model1, data1, probInfo1 = cuqi.testproblem.Deconvolution1D.get_components(dim=64)"
+    "model1, data1, probInfo1 = cuqi.testproblem.Deconvolution1D.get_components(dim=64, phantom=\"sinc\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here we define the testproblem with mostly default settings, except for the dimension and phantom type (exact solution).\n",
+    "\n",
     "Calling print around the model gives us some of the most important information about the model:"
    ]
   },
@@ -102,9 +104,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case we see that we are working with a LinearModel (linear in the operator sense), which makes sense for the deconvolution problem. We also see that the domain and range are both parametrized as Continous1D with 64 parameters. Finally, we see that the forward parameter is called 'x'.\n",
+    "In this case, we see that we are working with a LinearModel (linear in the operator sense), which makes sense for the deconvolution problem. We also see that the domain and range are both parametrized as Continous1D with 64 parameters. Finally, we see that the forward parameter is called 'x'.\n",
     "\n",
-    "The problem info typically contains both the exact synthetic signal `exactSolution` from which the data is produced and the exact simulated data `exactData`:"
+    "The problem info typically contains both the exact synthetic signal `exactSolution` from which the data was produced and the exact simulated data `exactData`:"
    ]
   },
   {
@@ -179,7 +181,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "CUQIpy offers a [2D image deblurring test problem](https://cuqi-dtu.github.io/CUQIpy/api/_autosummary/cuqi.testproblem/cuqi.testproblem.Deconvolution2D.html) as well, which can be set up in the same way as the 1D problem:"
+    "CUQIpy offers a [2D image deblurring test problem](https://cuqi-dtu.github.io/CUQIpy/api/_autosummary/cuqi.testproblem/cuqi.testproblem.Deconvolution2D.html) as well, which can be set up in the same way as the 1D problem (now with all default settings):"
    ]
   },
   {
@@ -307,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The data is the noisy observations of the temperature distribution after some time has passed (notice the difference in y-axis values below). We plot the data and the exact data as well as their difference:"
+    "The data is the noisy observations of the temperature distribution after some time has passed (notice the difference in y-axis values). We plot the data and the exact data as well as their difference:"
    ]
   },
   {
@@ -353,7 +355,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here the domain and range are parametrized as Continuous1D with 128 parameters, and the model is now noted as PDEModel."
+    "Here the domain and range are parametrized as Continuous1D with 128 parameters, and the model is now noted as PDEModel and a new field for a PDE is listed."
    ]
   },
   {
@@ -397,7 +399,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A,_,probInfo = cuqi.testproblem.Deconvolution1D.get_components(dim=64)\n",
+    "A,_,probInfo = cuqi.testproblem.Deconvolution1D.get_components(dim=64, phantom=\"sinc\")\n",
     "x_exact = probInfo.exactSolution"
    ]
   },
@@ -431,8 +433,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "z = A.adjoint(y_exact)\n",
-    "z = A.T@y_exact"
+    "z = A.adjoint(y_exact) # Explicitly call the adjoint method\n",
+    "z = A.T@y_exact        # Can also use short-hand for matrix transpose (gives the same result)"
    ]
   },
   {
@@ -457,7 +459,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When computing the forward, `A`passes its range geometry to the output. We can validate this by inspecting `y_exact` from earlier."
+    "When computing the forward operation, `A` passes its range geometry to the output. We can validate this by inspecting `y_exact` from earlier."
    ]
   },
   {
@@ -489,7 +491,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It can be useful to change to domain or range geometries of a model for example to work with different parametrizations. Here we change the range geometry of the model to [Discrete](https://cuqi-dtu.github.io/CUQIpy/api/_autosummary/cuqi.geometry/cuqi.geometry.Discrete.html) and see this reflected in the plotting of the computed output:"
+    "It can be useful to change to domain or range geometries of a model for example to work with different parametrizations or simply for visualization purposes.\n",
+    "\n",
+    "Here we change the range geometry of the model to [Discrete](https://cuqi-dtu.github.io/CUQIpy/api/_autosummary/cuqi.geometry/cuqi.geometry.Discrete.html) and see this reflected in the plotting of the computed output:"
    ]
   },
   {
@@ -655,13 +659,13 @@
     "\n",
     "One of the main tasks when working on numerical experiments for inverse problems is to generate synthetic data (potentially many realizations) to test and validate against. \n",
     "\n",
-    "In this section, we demonstrate one way this can be achieved by defining the so-called *data distribution*.\n",
+    "In this section, we demonstrate one way this can be achieved by defining the *data distribution*.\n",
     "\n",
-    "Let us return to the model from the deconvolution testproblem from earlier, and let us assume that the measurement data is affected by additive i.i.d. Gaussian noise. This leads to the inverse problem\n",
+    "Let us return to the model from the deconvolution testproblem from earlier, and let us assume that the measurement data is affected by additive i.i.d. Gaussian noise with standard deviation $0.05$. This leads to the inverse problem\n",
     "\n",
-    "$$\\mathbf{y} = \\mathbf{A}\\mathbf{x}+\\mathbf{e}.$$\n",
+    "$$\\mathbf{y}^\\mathrm{data} = \\mathbf{A}\\mathbf{x}^\\mathrm{exact}+\\mathbf{e},$$\n",
     "\n",
-    "The goal now is to generate examples of observed data $\\mathbf{y}$ assuming $\\mathbf{e}\\sim \\mathcal{N}(\\mathbf{0},0.05^2\\mathbf{I})$ given some $\\hat{\\mathbf{x}}$.\n",
+    "where the goal now is to generate examples of observed data assuming $\\mathbf{e}\\sim \\mathcal{N}(\\mathbf{0},0.05^2\\mathbf{I})$.\n",
     "\n",
     "**Note** *Generating noisy data in the above example with additive Gaussian noise is rather straightforward. However, the focus here is to provide a common framework for a much larger variety of models and noise types - exemplified by the Gaussian case.*"
    ]
@@ -671,14 +675,15 @@
    "metadata": {},
    "source": [
     "## 3.1 Data distribution\n",
-    "First, note that since $\\mathbf{e}$ is the only random contribution to $\\mathbf{y}$ when $\\mathbf{x}$ is fixed we can directly see that\n",
+    "First, note that since $\\mathbf{e}$ is the only random contribution to $\\mathbf{y}$ when $\\mathbf{x}$ is fixed we can directly see that for the model $\\mathbf{y} = \\mathbf{A}\\mathbf{x}$ we have\n",
     "\n",
-    "$$\\mathbf{y} | \\mathbf{x} \\sim \\mathcal{N}(\\mathbf{A}\\mathbf{x}, 0.05^2 \\mathbf{I}).$$\n",
+    "$$\\mathbf{y} \\mid \\mathbf{x} \\sim \\mathcal{N}(\\mathbf{A}\\mathbf{x}, 0.05^2 \\mathbf{I}).$$\n",
     "\n",
-    "We call the distribution associated with $p(\\mathbf{y}|\\mathbf{x})$ the *data distribution*. To generate synthetic data from $\\hat{\\mathbf{x}}$, we are thus interested in sampling from\n",
-    "$p(\\mathbf{y}|\\mathbf{x}=\\hat{\\mathbf{x}})$.\n",
+    "We call the distribution $p(\\mathbf{y} \\mid \\mathbf{x})$ associated with $\\mathbf{y} \\mid \\mathbf{x}$ the *data distribution*. \n",
+    "To generate synthetic data from $\\mathbf{x}^\\mathrm{exact}$, we are thus interested in sampling from\n",
+    "$p(\\mathbf{y} \\mid \\mathbf{x}=\\mathbf{x}^\\mathrm{exact})$.\n",
     "\n",
-    " Let us use the phantom from probInfo and extract the model again from the testproblem (just in case some changes were made above)"
+    "Let us use the phantom from probInfo and extract the model again from the testproblem (just in case some changes were made above)"
    ]
   },
   {
@@ -689,7 +694,7 @@
    "source": [
     "n = 64\n",
     "A, _, probInfo = cuqi.testproblem.Deconvolution1D.get_components(dim=n)\n",
-    "xhat = probInfo.exactSolution"
+    "x_exact = probInfo.exactSolution"
    ]
   },
   {
@@ -788,11 +793,11 @@
    "source": [
     "## 3.2 Sampling the data distribtuion\n",
     "\n",
-    "Evaluating a conditional distribution in CUQIpy is simply done by use of the \"call\" method on Python. That is, for the data distribution we would write `y(x=xhat)` or simply `y(xhat)`.\n",
+    "Evaluating a conditional distribution in CUQIpy is done by use of the \"call\" method on Python. That is, for the data distribution we would write `y(x=x_exact)` or simply `y(x_exact)`.\n",
     "\n",
-    "Evaluating the conditional distribution creates a new distribution, where the conditioning variable is fixed. That is, one can think of the expression `y(x=xhat)` as defining $p(\\mathbf{y}|\\mathbf{x}=\\hat{\\mathbf{x}})$. \n",
+    "Evaluating the conditional distribution creates a new distribution, where the conditioning variable is fixed. That is, one can think of the expression `y(x=x_exact)` as defining $p(\\mathbf{y} \\mid \\mathbf{x}=\\mathbf{x}^\\mathrm{exact})$. \n",
     "\n",
-    "Hence to simulate some noisy data, we just provide the conditioning variable `xhat` to the data distribution and then sample."
+    "Hence to simulate some noisy data, we just provide the conditioning variable `x_exact` to the data distribution and then sample."
    ]
   },
   {
@@ -801,7 +806,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y_obs = y(x=xhat).sample()\n",
+    "y_obs = y(x=x_exact).sample()\n",
     "y_obs.plot();\n",
     "plt.title(\"Generated synthetic data\");"
    ]
@@ -823,6 +828,7 @@
    "outputs": [],
    "source": [
     "# This is where you type the code:\n",
+    "\n",
     "\n"
    ]
   },
@@ -830,7 +836,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. ★ Creating custom models <a class=\"anchor\" id=\"custom\"></a>"
+    "## 4. Creating custom forward models <a class=\"anchor\" id=\"custom\"></a>"
    ]
   },
   {
@@ -906,7 +912,7 @@
    "source": [
     "To match the picture above, we select the column-major order by defining `order=\"F\"` (F comes from Fortran for historical reasons).\n",
     "\n",
-    "Furthermore, by default the `Image2D` will convert the input to an image before being evaluated by the model. In our case the matrix expected a vector, so we do not want this and thus set `visual_only=True` to not convert the vector to an image before evaluating the model."
+    "By default `Image2D` converts the input to an image before being evaluated by the model. In our case the matrix expects a vector, so we do not want this default behavior and thus set `visual_only=True` to not convert the vector to an image before model evaluation."
    ]
   },
   {
@@ -930,7 +936,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "which will allow us to display it nicely:"
+    "which will allow us to display it nicely, even through it is a stored as a vector:"
    ]
   },
   {
@@ -947,7 +953,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the row and column sum data we can for the purpose of the example let that be a Discrete geometry:"
+    "For the row and column sum data we can for the purpose of the example let that be a Discrete (labelled) geometry:"
    ]
   },
   {
@@ -1249,7 +1255,7 @@
     "# 5. ★ Forward UQ <a class=\"anchor\" id=\"forwardUQ\"></a>\n",
     "In some cases it may be interesting to see the effect a chosen prior has on the data-side, a so-called forward UQ analysis. This can easily be achieved using CUQIpy models and distributions. \n",
     "\n",
-    "For this case let us assume we have the data created from $\\hat{\\mathbf{x}}$ earlier, and we want to see if the prior encapsulates the measured data if we push it through forward model (ignoring noise in this case).\n",
+    "For this case let us assume we have the data created from $\\mathbf{x}^\\mathrm{exact}$ earlier, and we want to see if the prior encapsulates the measured data if we push it through forward model (ignoring noise in this case).\n",
     "\n",
     "To do this we first define our prior and generate some samples from it"
    ]
@@ -1287,15 +1293,15 @@
    "outputs": [],
    "source": [
     "xs.plot_ci(95)\n",
-    "xhat.plot()\n",
-    "plt.legend(['Mean of prior','xhat','Credibility interval'])"
+    "x_exact.plot()\n",
+    "plt.legend(['Mean of prior','x_exact','Credibility interval'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To perform the forward UQ and compare on the data-side, we essentially have to compute the forward for each sample.\n",
+    "To perform the forward UQ analysis and compare on the data-side, we essentially have to compute the forward for each sample.\n",
     "\n",
     "This would normally be done with for loop. However, because `xs` is a CUQIpy samples object and `A` is CUQIpy model, we can simply call the forward on the entire samples object (where once again the range geometry is passed from the model to the Samples on the data side)."
    ]
@@ -1313,7 +1319,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then compare the pushed-forward samples with the data generated earlier"
+    "We then compare the *push-forward* samples with the data generated earlier"
    ]
   },
   {
@@ -1326,11 +1332,21 @@
     "y_obs.plot()\n",
     "plt.legend(['Mean of push-forward prior', 'Actual data', 'Credibility interval'])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case the actual data is within the credibility interval of the push-forward prior, which is a good sign that the prior is a good representation of\n",
+    "the exact solution.\n",
+    "\n",
+    "This kind of forward UQ analysis is the stepping stone to the more general prior-predictive analysis, which we leave for future tutorials."
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.5 ('base')",
+   "display_name": "Python 3.8.8 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -1344,11 +1360,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   },
   "vscode": {
    "interpreter": {
-    "hash": "bdd0614febdc5d5cb7ca911d6da399e7bdecd3325d4f6cbaa40f1152134ae125"
+    "hash": "4ff4ac6af9578637e0e623c40bf41129eb04e2c9abec3a9480d43324f3a3fec8"
    }
   }
  },

--- a/training/Exercise03_Forward_Models.ipynb
+++ b/training/Exercise03_Forward_Models.ipynb
@@ -4,25 +4,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Exercise 03: Models, data generation and Forward UQ\n",
+    "# Exercise 03: Forward models, data generation and forward UQ\n",
     "\n",
-    "In this notebook, we dive into models in CUQIpy, generating simulated noisy data and some forward uncertainty quantification.\n",
+    "In this notebook, we dive into forward models in CUQIpy. In brief, a forward model is defined as a mathematical model that describes the models the relationship between some input parameters (which are often a quantity we can not directly observe) and some output data (which is observable).\n",
     "\n",
-    "Finally, we also show how to define new custom models in CUQIpy from either matrices or functions (methods in python).\n",
+    "In the context of inverse problems forward models are an important concept. What distinguishes forward models for inverse problems to any other kind of model of a physical system, is that they are *ill-posed*, which means existence, uniqueness and stability of inversion cannot be guaranteed. This deserves a separate discussion and we refer to [1] for the interested reader.\n",
+    "\n",
+    "For the purpose of this notebook, we show the basics of how to use forward models in CUQIpy. In particular for generating simulated noisy data and some forward uncertainty quantification. Finally, we also show how to define new custom linear or non-linear forward models in CUQIpy from either a matrix or functions.\n",
     "\n",
     "## Learning objectives\n",
-    "* Access and use pre-defined models from the CUQIpy testproblem library.\n",
-    "* Carry out basic operations of models such as forward evaluation.\n",
+    "Going through this notebook you will see how to\n",
+    "\n",
+    "* Access and use pre-defined forward models from the CUQIpy testproblem library.\n",
+    "* Carry out basic operations of forward models such as forward evaluation.\n",
     "* Generate noisy forward simulated data.\n",
-    "* Make a CUQIpy model from an existing matrix or function.\n",
+    "* Make a custom forward model from an existing matrix or function.\n",
     "* Run a simple forward UQ analysis.\n",
     "\n",
     "## Table of contents\n",
-    "1. [Access models from test problems](#testproblems)\n",
-    "2. [Basic usage of models](#models)\n",
+    "1. [Access forward models from test problems](#testproblems)\n",
+    "2. [Basic usage of forward models](#models)\n",
     "3. [Generating synthetic data](#data)\n",
-    "4. [★ Creating custom models](#custom)\n",
-    "5. [★ Forward UQ](#forwardUQ)"
+    "4. [★ Creating custom forward models](#custom)\n",
+    "5. [★ Forward UQ](#forwardUQ)\n",
+    "\n",
+    "## References\n",
+    "[1] Hansen, P. C. (2010). Discrete inverse problems: insight and algorithms. Society for Industrial and Applied Mathematics, [10.1137/1.9780898718836](https://epubs.siam.org/doi/book/10.1137/1.9780898718836)."
    ]
   },
   {
@@ -34,15 +41,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import sys\n",
-    "\n",
-    "sys.path.append(\"../../CUQIpy\")\n",
     "import cuqi"
    ]
   },
@@ -50,8 +54,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 1. Access models from test problems<a class=\"anchor\" id=\"testproblems\"></a>\n",
-    "Models in CUQIpy are the link between the solution/parameter, say $\\mathbf{x}$, and the data, say $\\mathbf{y}$. In their simplest form they are simply a mapping $A: \\mathbf{x} \\mapsto \\mathbf{y}$.\n",
+    "# 1. Access forward models from test problems<a class=\"anchor\" id=\"testproblems\"></a>\n",
+    "As mentioned in the introduction, forward models in CUQIpy are the link between the parameter of interest (which we call solution), say $\\mathbf{x}$, and the observed data, say $\\mathbf{y}$. In their simplest form they are simply a mapping $A: \\mathbf{x} \\mapsto \\mathbf{y}$.\n",
     "\n",
     "In addition to providing a mapping for the \"forward\" operation and potentially the adjoint, a CUQIpy model also contains information on the parametrization of its domain and range as well as possible gradients and so on. \n",
     "\n",
@@ -71,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1326,7 +1330,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.8 ('base')",
+   "display_name": "Python 3.8.5 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -1340,11 +1344,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.5"
   },
   "vscode": {
    "interpreter": {
-    "hash": "4ff4ac6af9578637e0e623c40bf41129eb04e2c9abec3a9480d43324f3a3fec8"
+    "hash": "bdd0614febdc5d5cb7ca911d6da399e7bdecd3325d4f6cbaa40f1152134ae125"
    }
   }
  },

--- a/training/Exercise03_Forward_Models.ipynb
+++ b/training/Exercise03_Forward_Models.ipynb
@@ -661,11 +661,11 @@
     "\n",
     "In this section, we demonstrate one way this can be achieved by defining the *data distribution*.\n",
     "\n",
-    "Let us return to the model from the deconvolution testproblem from earlier, and let us assume that the measurement data is affected by additive i.i.d. Gaussian noise with standard deviation $0.05$. This leads to the inverse problem\n",
+    "Let us return to the model from the deconvolution testproblem from earlier, and let us assume that the measurement data is affected by additive i.i.d. Gaussian noise with standard deviation $0.05$. This leads to the Bayesian model for the inverse problem\n",
     "\n",
-    "$$\\mathbf{y}^\\mathrm{data} = \\mathbf{A}\\mathbf{x}^\\mathrm{exact}+\\mathbf{e},$$\n",
+    "$$\\mathbf{y} = \\mathbf{A}\\mathbf{x}+\\mathbf{e},$$\n",
     "\n",
-    "where the goal now is to generate examples of observed data assuming $\\mathbf{e}\\sim \\mathcal{N}(\\mathbf{0},0.05^2\\mathbf{I})$.\n",
+    "where $\\mathbf{y}$, $\\mathbf{x}$ and $\\mathbf{e}$ are random variables and where the goal now is to generate examples of observed data assuming $\\mathbf{e}\\sim \\mathcal{N}(\\mathbf{0},0.05^2\\mathbf{I})$ and given some exact solution vector $\\mathbf{x}_\\mathrm{exact}$.\n",
     "\n",
     "**Note** *Generating noisy data in the above example with additive Gaussian noise is rather straightforward. However, the focus here is to provide a common framework for a much larger variety of models and noise types - exemplified by the Gaussian case.*"
    ]
@@ -675,13 +675,13 @@
    "metadata": {},
    "source": [
     "## 3.1 Data distribution\n",
-    "First, note that since $\\mathbf{e}$ is the only random contribution to $\\mathbf{y}$ when $\\mathbf{x}$ is fixed we can directly see that for the model $\\mathbf{y} = \\mathbf{A}\\mathbf{x}$ we have\n",
+    "First, note that since $\\mathbf{e}$ is the only random contribution to $\\mathbf{y}$ when $\\mathbf{x}$ is fixed we can directly see that \n",
     "\n",
     "$$\\mathbf{y} \\mid \\mathbf{x} \\sim \\mathcal{N}(\\mathbf{A}\\mathbf{x}, 0.05^2 \\mathbf{I}).$$\n",
     "\n",
-    "We call the distribution $p(\\mathbf{y} \\mid \\mathbf{x})$ associated with $\\mathbf{y} \\mid \\mathbf{x}$ the *data distribution*. \n",
-    "To generate synthetic data from $\\mathbf{x}^\\mathrm{exact}$, we are thus interested in sampling from\n",
-    "$p(\\mathbf{y} \\mid \\mathbf{x}=\\mathbf{x}^\\mathrm{exact})$.\n",
+    "We call the distribution $p(\\mathbf{y} \\mid \\mathbf{x})$ associated with $\\mathbf{y} \\mid \\mathbf{x}$ a *data distribution*. \n",
+    "To generate synthetic data from $\\mathbf{x}_\\mathrm{exact}$, we are thus interested in sampling from\n",
+    "$p(\\mathbf{y} \\mid \\mathbf{x}=\\mathbf{x}_\\mathrm{exact})$.\n",
     "\n",
     "Let us use the phantom from probInfo and extract the model again from the testproblem (just in case some changes were made above)"
    ]
@@ -791,11 +791,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.2 Sampling the data distribtuion\n",
+    "## 3.2 Sampling a data distribtuion\n",
     "\n",
-    "Evaluating a conditional distribution in CUQIpy is done by use of the \"call\" method on Python. That is, for the data distribution we would write `y(x=x_exact)` or simply `y(x_exact)`.\n",
+    "Evaluating a conditional distribution in CUQIpy is done by use of the \"call\" method on Python. That is, for a data distribution we would write `y(x=x_exact)` or simply `y(x_exact)`.\n",
     "\n",
-    "Evaluating the conditional distribution creates a new distribution, where the conditioning variable is fixed. That is, one can think of the expression `y(x=x_exact)` as defining $p(\\mathbf{y} \\mid \\mathbf{x}=\\mathbf{x}^\\mathrm{exact})$. \n",
+    "Evaluating the conditional distribution creates a new distribution, where the conditioning variable is fixed. That is, one can think of the expression `y(x=x_exact)` as defining $p(\\mathbf{y} \\mid \\mathbf{x}=\\mathbf{x}_\\mathrm{exact})$. \n",
     "\n",
     "Hence to simulate some noisy data, we just provide the conditioning variable `x_exact` to the data distribution and then sample."
    ]
@@ -1346,7 +1346,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.8 ('base')",
+   "display_name": "Python 3.8.5 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -1360,11 +1360,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.5"
   },
   "vscode": {
    "interpreter": {
-    "hash": "4ff4ac6af9578637e0e623c40bf41129eb04e2c9abec3a9480d43324f3a3fec8"
+    "hash": "bdd0614febdc5d5cb7ca911d6da399e7bdecd3325d4f6cbaa40f1152134ae125"
    }
   }
  },

--- a/training/Exercise03_Forward_Models.ipynb
+++ b/training/Exercise03_Forward_Models.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "In this notebook, we dive into forward models in CUQIpy. In brief, a forward model is defined as a mathematical model that describes the relationship between some input parameters (which are not directly observable) and some output data (which is observable).\n",
     "\n",
-    "In the context of inverse problems forward models are an important concept. What distinguishes forward models for inverse problems to any other kind of model of a physical system, is that they are *ill-posed*, which means existence, uniqueness and stability of inversion cannot be guaranteed. This deserves a separate discussion, which is out-of-scope for this notebook and we refer to [1] for the interested reader.\n",
+    "In the context of inverse problems forward models are an important concept. What distinguishes forward models for inverse problems to any other kind of model of a physical system, is that they are typically *ill-posed*, which means that existence, uniqueness and/or stability of inversion cannot be guaranteed. This deserves a separate discussion, which is out-of-scope for this notebook and we refer to [1] for the interested reader.\n",
     "\n",
     "For the purpose of this notebook, we show the basics of how to use forward models in CUQIpy. In particular for generating simulated noisy data and some forward uncertainty quantification. Finally, we also show how to define new custom linear or non-linear forward models in CUQIpy from either a matrix or functions.\n",
     "\n",
@@ -661,7 +661,7 @@
     "\n",
     "In this section, we demonstrate one way this can be achieved by defining the *data distribution*.\n",
     "\n",
-    "Let us return to the model from the deconvolution testproblem from earlier, and let us assume that the measurement data is affected by additive i.i.d. Gaussian noise with standard deviation $0.05$. This leads to the Bayesian model for the inverse problem\n",
+    "Let us return to the forward model from the deconvolution testproblem from earlier, and let us assume that the measurement data is affected by additive i.i.d. Gaussian noise with standard deviation $0.05$. This leads to the Bayesian model for the inverse problem\n",
     "\n",
     "$$\\mathbf{y} = \\mathbf{A}\\mathbf{x}+\\mathbf{e},$$\n",
     "\n",
@@ -953,7 +953,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the row and column sum data we can for the purpose of the example let that be a Discrete (labelled) geometry:"
+    "The row and column sum data we can - for the purpose of the example - let be of the type Discrete (labelled) geometry:"
    ]
   },
   {


### PR DESCRIPTION
Closes #38 

- Replaced model with forward model in most cases.
- Added a bit more initial explanation of why forward models are important.
- Made section 4 not star (custom forward models)
- Made notation more consistent (used y^data and x^exact for specific vectors) and left x and y as random variables always.
- Minor typos etc.